### PR TITLE
Add log binding to script executor

### DIFF
--- a/src/main/groovy/org/gaelyk/console/ConsoleScriptExecutor.groovy
+++ b/src/main/groovy/org/gaelyk/console/ConsoleScriptExecutor.groovy
@@ -1,6 +1,7 @@
 package org.gaelyk.console
 
 import groovyx.gaelyk.GaelykBindingEnhancer
+import groovyx.gaelyk.logging.GroovyLogger
 import groovyx.gaelyk.plugins.PluginsHandler
 
 class ConsoleScriptExecutor {
@@ -10,6 +11,7 @@ class ConsoleScriptExecutor {
 		Binding binding = new Binding()
 		binding.out = out
 		binding.report = new ChannelReporter(channelId)
+        binding.log = new OutLogger(out)
 		GaelykBindingEnhancer.bind(binding)
 		PluginsHandler.instance.enrich(binding)
 		GroovyShell shell = new GroovyShell(binding)
@@ -18,7 +20,42 @@ class ConsoleScriptExecutor {
 			return [result: result ? (result.toString()) : '', output: out.toString()]
 		} catch (Throwable e){
 			return [exception: e, output: out.toString()]
-		}
+        }
 	}
+}
 
+class OutLogger {
+    private out
+    
+    def OutLogger(out) {
+        this.out = out
+    }
+
+    def finest(string) {
+        this.out << "FINEST: ${string}\n"
+    }
+        
+    def finer(string) {
+        this.out << "FINER: ${string}\n"
+    }
+    
+    def fine(string) {
+        this.out << "FINE: ${string}\n"
+    }
+    
+    def config(string) {
+        this.out << "CONFIG: ${string}\n"
+    }
+    
+    def info(string) {
+        this.out << "INFO: ${string}\n"
+    }
+    
+    def warning(string) {
+        this.out << "WARNING: ${string}\n"
+    }
+    
+    def severe(string) {
+        this.out << "SEVERE: ${string}\n"
+    }
 }

--- a/src/main/groovy/org/gaelyk/console/ConsoleScriptExecutor.groovy
+++ b/src/main/groovy/org/gaelyk/console/ConsoleScriptExecutor.groovy
@@ -1,7 +1,6 @@
 package org.gaelyk.console
 
 import groovyx.gaelyk.GaelykBindingEnhancer
-import groovyx.gaelyk.logging.GroovyLogger
 import groovyx.gaelyk.plugins.PluginsHandler
 
 class ConsoleScriptExecutor {
@@ -11,7 +10,7 @@ class ConsoleScriptExecutor {
 		Binding binding = new Binding()
 		binding.out = out
 		binding.report = new ChannelReporter(channelId)
-        binding.log = new OutLogger(out)
+ 		binding.log = new OutLogger(out)
 		GaelykBindingEnhancer.bind(binding)
 		PluginsHandler.instance.enrich(binding)
 		GroovyShell shell = new GroovyShell(binding)

--- a/src/test/groovy/org/gaelyk/console/ConsoleScriptExecutorSpec.groovy
+++ b/src/test/groovy/org/gaelyk/console/ConsoleScriptExecutorSpec.groovy
@@ -104,8 +104,14 @@ class ConsoleScriptExecutorSpec extends Specification {
         result.result == "11"
         result.output == "Hello World!"
     }
-    
-    
-	
 
+    def "Log works"(){
+        def result = ConsoleScriptExecutor.evaluate "channel", """
+            log.info 'Logging is informative!'
+        """
+        
+        expect:
+        !result.exception
+        result.output == "INFO: Logging is informative!\n"
+    }
 }


### PR DESCRIPTION
I always have to switch all my log statements into printlns when pasting code into the gaelyk console for testing.  This makes a fake log binding that just dumps anything logged into the output.   

Let me know if you have any questions or feedback.